### PR TITLE
Fixing-span-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
+![It did not work.](https://assetsnffrgf-a.akamaihd.net/assets/m/2021080/univ/art/2021080_univ_lss_lg.jpg)
+
 ## organize-availability-survey-results
 
 This script is bound to a *Google Sheet*. When run, it takes the results for a survey and creates a sheet for each unique response for a given question. This sheet will have a `=QUERY()` formula added that will grab all the responses from the main response sheet (one linked to a *Google Form*) that have that specific answer choice. The `=QUERY()` will also sort the responses slightly. This was originally made to sort the student responses for a tutoring availability survey. The original add-on that was being used was breaking due to some answer choices having unescaped double quotes (" should go to "") and lengths exceeding the maximum allowed for sheet names (100 characters). 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![🟦](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
+## Trying other span attributes
+
+An <span style="text-decoration: overline;">over-lined</span> word.
+
 ## organize-availability-survey-results
 
 This script is bound to a *Google Sheet*. When run, it takes the results for a survey and creates a sheet for each unique response for a given question. This sheet will have a `=QUERY()` formula added that will grab all the responses from the main response sheet (one linked to a *Google Form*) that have that specific answer choice. The `=QUERY()` will also sort the responses slightly. This was originally made to sort the student responses for a tutoring availability survey. The original add-on that was being used was breaking due to some answer choices having unescaped double quotes (" should go to "") and lengths exceeding the maximum allowed for sheet names (100 characters). 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
-![It did not work.](https://assetsnffrgf-a.akamaihd.net/assets/m/2021080/univ/art/2021080_univ_lss_lg.jpg)
+[It did not work.](https://via.placeholder.com/15/6495ed/000000?text=+)
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
-[It did not work.](https://via.placeholder.com/15/6495ed/000000?text=+)
+![It did not work.](https://via.placeholder.com/15/6495ed/000000?text=+)
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <u>cornflowerblue</u> as the color. 
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ED/000000?text=+) cornflowerblue as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![:blue_square:](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![🟦](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <span style="color: blue;">cornflowerblue</span> as the color. 
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <span style="color: cornflowerblue;">cornflowerblue</span> as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <span style="color: cornflowerblue;">cornflowerblue</span> as the color. 
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <u>cornflowerblue</u> as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <span style="color:cornflowerblue;">cornflowerblue</span> as the color. 
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and <span style="color: blue;">cornflowerblue</span> as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
-![It did not work.](https://via.placeholder.com/15/c5f015/000000?text=+)
+![It did not work.](https://assetsnffrgf-a.akamaihd.net/assets/m/2021080/univ/art/2021080_univ_lss_lg.jpg)
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
-
-![It did not work.](https://via.placeholder.com/15/6495ed/000000?text=+)
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![:blue_square:](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 ## meeting-part-colorizer
 
-This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ED/000000?text=+) cornflowerblue as the color. 
+This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
 ## organize-availability-survey-results
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This script is bound to a *Google Sheet*. It implements a solver for the game *M
 
 This script is bound to a *Google Doc*. When run, it looks at the whole document and turns and paragraph that starts with the pattern `{letter}:`, and makes the text have a specific color. As of now there is no driver function, so the function just uses `V` as the letter and ![#6495ED](https://via.placeholder.com/15/6495ed/000000?text=+) cornflowerblue as the color. 
 
-![It did not work.](https://assetsnffrgf-a.akamaihd.net/assets/m/2021080/univ/art/2021080_univ_lss_lg.jpg)
+![It did not work.](https://via.placeholder.com/15/c5f015/000000?text=+)
 
 ## organize-availability-survey-results
 


### PR DESCRIPTION
I originally thought that github would be able to render inline HTML. However, it seems that my attempts at styling a span with inline styles have not worked. The next attempt involved using an image square with the desired color. However, that led to "Invalid upstream response (403)" on the image. That image link is still there, but the fallback is the blue_square emoji.